### PR TITLE
feat: add getPastCandles reader function

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -29,6 +29,19 @@ class BitcoinPriceFeedReader extends Reader {
   }
 
   /**
+   * Read the past candles of a given trading pair and period.
+   *
+   * @param {Pair} pair
+   * @param {Period} period
+   * @returns {Promise<Candle[] | null>}
+   */
+  async getPastCandles (pair, period) {
+    const response = await this.getField(`${pair}-${period}`)
+
+    return response ? response.map(mapCandle) : null
+  }
+
+  /**
    * Read the daily candles of a trading pair.
    *
    * @param {Pair} pair
@@ -119,6 +132,7 @@ module.exports = BitcoinPriceFeedReader
 
 /**
  * @typedef {'BTCUSD' | 'BTCEUR' | 'BTCUST' | 'BTCGBP' | 'BTCJPY'} Pair
+ * @typedef {'1D' | '1W' | '1M'} Period
  * @typedef {{
  *  price: number,
  *  timestamp: number

--- a/types/lib/reader.d.ts
+++ b/types/lib/reader.d.ts
@@ -15,6 +15,14 @@ declare class BitcoinPriceFeedReader extends Reader {
      */
     getLatestPriceTimestamped(pair: Pair): Promise<TimestampedPrice | null>;
     /**
+     * Read the past candles of a given trading pair and period.
+     *
+     * @param {Pair} pair
+     * @param {Period} period
+     * @returns {Promise<Candle[] | null>}
+     */
+    getPastCandles(pair: Pair, period: Period): Promise<Candle[] | null>;
+    /**
      * Read the daily candles of a trading pair.
      *
      * @param {Pair} pair
@@ -57,10 +65,11 @@ declare class BitcoinPriceFeedReader extends Reader {
     subscribePastMonthCandles(pair: Pair, callback: (candles: Candle[]) => void): () => void;
 }
 declare namespace BitcoinPriceFeedReader {
-    export { Pair, TimestampedPrice, Candle };
+    export { Pair, Period, TimestampedPrice, Candle };
 }
 import { Reader } from "@synonymdev/feeds";
 type Pair = 'BTCUSD' | 'BTCEUR' | 'BTCUST' | 'BTCGBP' | 'BTCJPY';
+type Period = '1D' | '1W' | '1M';
 type TimestampedPrice = {
     price: number;
     timestamp: number;


### PR DESCRIPTION
Adds a helper `getPastCandles` that returns candles for a given period. Useful if I have a list of periods that I want to iterate over to get all past candles.